### PR TITLE
correct cdr source

### DIFF
--- a/sources/cdr.zsh
+++ b/sources/cdr.zsh
@@ -7,7 +7,8 @@
 (( $+functions[cdr] )) || return
 
 function zaw-src-cdr () {
-    : ${(A)candidates::=${${(f)"$(cdr -l | awk '{print $2}')"}##<-> ##}}
+    setopt local_options extended_glob
+    : ${(A)candidates::=${${(f)"$(cdr -l)"}##<-> ##}}
     actions=(zaw-src-cdr-cd zaw-src-cdr-insert zaw-src-cdr-prune)
     act_descriptions=("cd" "insert" "prune")
     options+=(-m)


### PR DESCRIPTION
cdr source does not work well in the recent zsh 
(at least in the version 4.3.17).

Please fix it.
