### PR TITLE
zaw-src-applications: On Mac OSX, use mdfind/locate/glob

### DIFF
--- a/sources/applications.zsh
+++ b/sources/applications.zsh
@@ -15,12 +15,15 @@ function zaw-src-applications() {
             (( ${+commands[mdfind]} )) && \
                 candidates+=(${(f)"$(mdfind -onlyin / 'kMDItemKind == "Application"' 2>/dev/null)"})
 
-            # mdfind does not find apps inside apps (e.g. inside Adobe Reader)
-            # whereas locate's index does, so add that too if available to be
-            # more complete. This also helps if one or the other index is a bit
-            # stale.
-            (( ${+commands[locate]} && ${+commands[grep]} )) && \
-                candidates+=(${(f)"$((locate -i '.app' | grep -i '\.app$') 2>/dev/null)"})
+            # Use locate if available and no output from spotlight or if forced use by ZAW_SRC_APPLICATIONS_USE_LOCATE
+            if (( ${+commands[locate]} )) && [ -n "$ZAW_SRC_APPLICATIONS_USE_LOCATE" -o $#candidates -eq 0 ]; then
+                # Apps inside apps are not normally useful
+                if [ -n "$ZAW_SRC_APPLICATIONS_INTERNAL_APPS_OK" ]; then
+                    candidates+=(${(f)"$(locate -i '*.app' 2>/dev/null)"})
+                elif [ ${+commands[grep]} -eq 1 ]; then
+                    candidates+=(${(f)"$((locate -i '*.app' | grep -iv '\.app/') 2>/dev/null)"})
+                fi
+            fi
 
             # Glob common locations anyway since both of previous indexes may
             # be stale or non-existent


### PR DESCRIPTION
...to get the best listing possible in all cases.

This follows the discussion on https://github.com/zsh-users/zaw/issues/16 but slightly deviates from it in using all three candidate sources for a more exhaustive listing that is still performant enough.
