### PR TITLE
support ack-grep

### DIFF
--- a/sources/ack.zsh
+++ b/sources/ack.zsh
@@ -20,7 +20,7 @@ autoload -U read-from-minibuffer
 function zaw-src-ack() {
     local ack_args REPLY f line ret
     local -a ack_history
-    ack_history=( "${(@)${(f)"$(fc -l -n -m $ACK_COMMAND "*" 0 -1)"}#ack }" )
+    ack_history=( "${(@)${(f)"$(fc -l -n -m "$ACK_COMMAND *" 0 -1)"}#ack }" )
 
     function() {
         local HISTNO


### PR DESCRIPTION
Debian provides `ack-grep` instead of `ack`. This pr supports this command.
cf: http://beyondgrep.com/install/
