### PR TITLE
support ZAW_EDITOR value

### DIFF
--- a/zaw.zsh
+++ b/zaw.zsh
@@ -193,7 +193,12 @@ function zaw-callback-append-to-buffer() {
 function zaw-callback-edit-file() {
     local -a args
     args=("${(@q)@}")
-    BUFFER="${EDITOR} ${args}"
+
+    if [ ! ${ZAW_EDITOR} ]; then
+      ZAW_EDITOR=${EDITOR}
+    fi
+
+    BUFFER="${ZAW_EDITOR} ${args}"
     zle accept-line
 }
 


### PR DESCRIPTION
Usually many user use EDITOR as commit message editor, so
EDITOR block process.
Therefore I don't want to block process when editor is opened
from zaw. So I use separate environment value ZAW_EDITOR.
If ZAW_EDITOR value is not set, zaw try to use EDITOR.
