### PR TITLE
Add fasd sources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,9 @@ currently these sources are available:
   - screens
   - ssh-hosts
   - tmux
+  - fasd
+  - fasd-directories
+  - fasd-files
 
 (Note: git-files-legacy is an alternative for git-files.
 git-files classifies modified files, git-files-legacy doesn't do it for
@@ -85,6 +88,9 @@ you can get all available shortcut widgets' name using ``zaw-print-src``::
   screens          zaw-screens
   ssh-hosts        zaw-ssh-hosts
   tmux             zaw-tmux
+  fasd             zaw-fasd
+  fasd-directories zaw-directories
+  fasd-files       zaw-files
 
 
 key binds and styles

--- a/sources/fasd.zsh
+++ b/sources/fasd.zsh
@@ -1,0 +1,27 @@
+function zaw-src-fasd () {
+    candidates=($(fasd -al))
+    actions=(zaw-callback-append-to-buffer)
+    act_descriptions=("append to edit buffer")
+    options+=(-n -m)
+}
+
+
+function zaw-src-fasd-f () {
+    candidates=($(fasd -fl))
+    actions=(zaw-callback-append-to-buffer)
+    act_descriptions=("append to edit buffer")
+    options+=(-n -m)
+}
+
+
+function zaw-src-fasd-d () {
+    candidates=($(fasd -dl))
+    actions=(zaw-callback-append-to-buffer)
+    act_descriptions=("append to edit buffer")
+    options+=(-n -m)
+}
+
+
+zaw-register-src -n fasd-a zaw-src-fasd-a
+zaw-register-src -n fasd-d zaw-src-fasd-d
+zaw-register-src -n fasd-f zaw-src-fasd-f

--- a/sources/fasd.zsh
+++ b/sources/fasd.zsh
@@ -6,7 +6,7 @@ function zaw-src-fasd () {
 }
 
 
-function zaw-src-fasd-f () {
+function zaw-src-fasd-files () {
     candidates=($(fasd -fl))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
@@ -14,7 +14,7 @@ function zaw-src-fasd-f () {
 }
 
 
-function zaw-src-fasd-d () {
+function zaw-src-fasd-directories () {
     candidates=($(fasd -dl))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
@@ -22,6 +22,6 @@ function zaw-src-fasd-d () {
 }
 
 
-zaw-register-src -n fasd-a zaw-src-fasd-a
-zaw-register-src -n fasd-d zaw-src-fasd-d
-zaw-register-src -n fasd-f zaw-src-fasd-f
+zaw-register-src -n fasd zaw-src-fasd
+zaw-register-src -n fasd-directories zaw-src-fasd-directories
+zaw-register-src -n fasd-files zaw-src-fasd-files


### PR DESCRIPTION
I add following three sources for [`fasd`](https://github.com/clvv/fasd) mentioned in issue #34.

 - fasd: any file and directory 
 - fasd-directory: only directory
 - fasd-file: only file

These sources need [`fasd`](https://github.com/clvv/fasd).
