### PR TITLE
Git log source

### DIFF
--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -2,7 +2,8 @@
 function zaw-src-git-log() {
     git rev-parse --git-dir >/dev/null 2>&1
     if [[ $? == 0 ]]; then
-        local desc="$(git log --all --graph --decorate --oneline)"
+        local desc="$(git log --all --graph --decorate --oneline --no-color)"
+        
         : ${(A)cand_descriptions::=${(f)desc}}
         : ${(A)candidates::=${(f)desc}}
     fi

--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -20,7 +20,7 @@ function zaw-src-git-log() {
 }
 
 function _zaw-src-git-log-strip(){
-    echo $1 | sed -e 's/^[*|/\\ ]* \([a-f0-9]*\) .*/\1/' -er "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
+    echo $1 | sed -e 's/^[*|/\\ ]* \([a-f0-9]*\) .*/\1/'
 }
 
 function zaw-src-git-log-insert(){

--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -20,7 +20,7 @@ function zaw-src-git-log() {
 }
 
 function _zaw-src-git-log-strip(){
-    echo $1 | sed -e 's/^[*|/\\ ]* \([a-f0-9]*\) .*/\1/'
+    echo $1 | sed -e 's/^[*|/\\ ]* \([a-f0-9]*\) .*/\1/' -er "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
 }
 
 function zaw-src-git-log-insert(){

--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -1,0 +1,23 @@
+
+function zaw-src-git-log() {
+    git rev-parse --git-dir >/dev/null 2>&1
+    if [[ $? == 0 ]]; then
+        local desc="$(git log --all --graph --decorate --oneline)"
+        : ${(A)cand_descriptions::=${(f)desc}}
+        : ${(A)candidates::=${(f)desc}}
+    fi
+    actions=(zaw-src-git-log-insert)
+    act_descriptions=("insert")
+    options=()
+}
+
+function _zaw-src-git-log-strip(){
+    echo $1 | sed -e 's/^[*|/\\ ]* \([a-f0-9]*\) .*/\1/'
+}
+
+function zaw-src-git-log-insert(){
+    local hash_val=$(_zaw-src-git-log-strip $1)
+    zaw-callback-append-to-buffer $hash_val
+}
+
+zaw-register-src -n git-log zaw-src-git-log

--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -10,11 +10,13 @@ function zaw-src-git-log() {
     actions=(zaw-src-git-log-insert \
              zaw-src-git-log-reset \
              zaw-src-git-log-reset-hard \
+             zaw-src-git-log-cherry-pick \
              zaw-src-git-log-create-branch \
              zaw-src-git-log-revert)
     act_descriptions=("insert" \
                       "reset" \
                       "reset --hard" \
+                      "cherry-pick" \
                       "create new branch from this hash value" \
                       "revert")
     options=()
@@ -38,6 +40,12 @@ function zaw-src-git-log-reset(){
 function zaw-src-git-log-reset-hard(){
     local hash_val=$(_zaw-src-git-log-strip $1)
     BUFFER="git reset --hard $hash_val"
+    zle accept-line
+}
+
+function zaw-src-git-log-cherry-pick(){
+    local hash_val=$(_zaw-src-git-log-strip $1)
+    BUFFER="git cherry-pick $hash_val"
     zle accept-line
 }
 

--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -6,8 +6,16 @@ function zaw-src-git-log() {
         : ${(A)cand_descriptions::=${(f)desc}}
         : ${(A)candidates::=${(f)desc}}
     fi
-    actions=(zaw-src-git-log-insert)
-    act_descriptions=("insert")
+    actions=(zaw-src-git-log-insert \
+             zaw-src-git-log-reset \
+             zaw-src-git-log-reset-hard \
+             zaw-src-git-log-create-branch \
+             zaw-src-git-log-revert)
+    act_descriptions=("insert" \
+                      "reset" \
+                      "reset --hard" \
+                      "create new branch from this hash value" \
+                      "revert")
     options=()
 }
 
@@ -18,6 +26,30 @@ function _zaw-src-git-log-strip(){
 function zaw-src-git-log-insert(){
     local hash_val=$(_zaw-src-git-log-strip $1)
     zaw-callback-append-to-buffer $hash_val
+}
+
+function zaw-src-git-log-reset(){
+    local hash_val=$(_zaw-src-git-log-strip $1)
+    BUFFER="git reset $hash_val"
+    zle accept-line
+}
+
+function zaw-src-git-log-reset-hard(){
+    local hash_val=$(_zaw-src-git-log-strip $1)
+    BUFFER="git reset --hard $hash_val"
+    zle accept-line
+}
+
+function zaw-src-git-log-create-branch(){
+    local hash_val=$(_zaw-src-git-log-strip $1)
+    LBUFFER="git checkout -b "
+    RBUFFER=" $hash_val"
+}
+
+function zaw-src-git-log-revert(){
+    local hash_val=$(_zaw-src-git-log-strip $1)
+    BUFFER="git revert $hash_val"
+    zle accept-line
 }
 
 zaw-register-src -n git-log zaw-src-git-log


### PR DESCRIPTION
I create a source for git-log.
It uses the output of `git log --all --graph --decorate --oneline` to do the following actions:

- insert hash value
- reset
- reset --hard
- create new branch from the hash
- revert

