### PR TITLE
Check for ack-grep before checking for ack

### DIFF
--- a/sources/ack.zsh
+++ b/sources/ack.zsh
@@ -6,10 +6,10 @@
 
 zmodload zsh/parameter
 
-if (( $+commands[ack] )); then
-    ACK_COMMAND="ack"
-elif (( $+commands[ack-grep] )); then
+if (( $+commands[ack-grep] )); then
     ACK_COMMAND="ack-grep"
+elif (( $+commands[ack] )); then
+    ACK_COMMAND="ack"
 else
     # ack not found
     return

--- a/sources/aliases.zsh
+++ b/sources/aliases.zsh
@@ -1,0 +1,24 @@
+#
+# zaw-src-aliases
+#
+# select an alias and expand it
+#
+
+zmodload zsh/parameter
+
+autoload -U read-from-minibuffer
+
+function zaw-src-aliases() {
+    local REPLY f line ret
+    if [[ "$LBUFFER" =~ "\w" ]]; then
+        candidates=("${(v@)galiases}")
+        cand_descriptions=("${(k@)galiases}")
+    else
+        candidates=("${(v@)aliases}")
+        cand_descriptions=("${(k@)aliases}")
+    fi
+    actions=("zaw-callback-append-to-buffer" "zaw-callback-execute")
+    act_descriptions=("append to edit buffer" "execute")
+}
+
+zaw-register-src -n aliases zaw-src-aliases


### PR DESCRIPTION
To avoid confusion with the ubuntu ack package for Kanji code conversion: http://manpages.ubuntu.com/manpages/precise/man1/ack.1.html