### PR TITLE
fixed process search on Mac OS X

### DIFF
--- a/sources/process.zsh
+++ b/sources/process.zsh
@@ -2,7 +2,11 @@
 
 function zaw-src-process () {
     local ps_list title ps pid_list
-    ps_list="$(ps -aux --sort args | awk '$11 !~ /^\[/ {print $0}')" # filter out kernel processes
+    if [ $(uname) = "Darwin" ] ; then       # for Macintosh
+        ps_list="$(ps aux | awk '$11 !~ /^\[/ {print $0}')"              # filter out kernel processes
+    else
+        ps_list="$(ps -aux --sort args | awk '$11 !~ /^\[/ {print $0}')" # filter out kernel processes
+    fi
     title="${${(f)ps_list}[1]}"
     ps="$(echo $ps_list | sed '1d')"
     pid_list="$(echo $ps | awk '{print $2}')"


### PR DESCRIPTION
fixed #31, but ps list is not sorted.
