### PR TITLE
Quote file paths not to parse shell meta characters

### DIFF
--- a/sources/git-status.zsh
+++ b/sources/git-status.zsh
@@ -19,28 +19,28 @@ function zaw-src-git-status() {
 function zaw-src-git-status-add() {
   local f_path=${1#(\?\? | M |M  |A  )}
   local git_base="$(git rev-parse --show-cdup)"
-  BUFFER="git add $git_base$f_path"
+  BUFFER="git add '$git_base$f_path'"
   zle accept-line
 }
 
 function zaw-src-git-status-add-p() {
   local f_path=${1#(\?\? | M |M  |A  )}
   local git_base="$(git rev-parse --show-cdup)"
-  BUFFER="git add -p $git_base$f_path"
+  BUFFER="git add -p '$git_base$f_path'"
   zle accept-line
 }
 
 function zaw-src-git-status-reset() {
   local f_path=${1#(\?\? | M |M  |A  )}
   local git_base="$(git rev-parse --show-cdup)"
-  BUFFER="git reset $git_base$f_path"
+  BUFFER="git reset '$git_base$f_path'"
   zle accept-line
 }
 
 function zaw-src-git-status-checkout() {
   local f_path=${1#(\?\? | M |M  |A  )}
   local git_base="$(git rev-parse --show-cdup)"
-  BUFFER="git checkout $git_base$f_path"
+  BUFFER="git checkout '$git_base$f_path'"
   zle accept-line
 }
 


### PR DESCRIPTION
When there are files whose names have shell meta characters (e.g. `#`), the actions in the git-status plugin fail by them. This commit adds quotes so that the file names will not be parsed by shell.