### PR TITLE
Add `AM` and `MM` status

### DIFF
--- a/sources/git-status.zsh
+++ b/sources/git-status.zsh
@@ -7,6 +7,8 @@ function zaw-src-git-status() {
       : ${(A)cand_descriptions::=${${(f)${file_list}}/ M /[modified]    }}
       : ${(A)cand_descriptions::=${${(M)cand_descriptions}/M  /[staged]      }}
       : ${(A)cand_descriptions::=${${(M)cand_descriptions}/A  /[staged(add)] }}
+      : ${(A)cand_descriptions::=${${(M)cand_descriptions}/MM /[staged][modified] }}
+      : ${(A)cand_descriptions::=${${(M)cand_descriptions}/AM /[staged(add)][modified] }}
       : ${(A)cand_descriptions::=${${(M)cand_descriptions}/\?\? /[untracked]   }}
 
     fi


### PR DESCRIPTION
Adding support of `AM` (added, staged and modified) and `MM` (staged and modified) state to the git-status plugin.