### PR TITLE
Add -p option to remove prefix from initbufer

### DIFF
--- a/sources/cdr.zsh
+++ b/sources/cdr.zsh
@@ -11,7 +11,7 @@ function zaw-src-cdr () {
     : ${(A)candidates::=${${(f)"$(cdr -l)"}##<-> ##}}
     actions=(zaw-src-cdr-cd zaw-src-cdr-insert zaw-src-cdr-prune)
     act_descriptions=("cd" "insert" "prune")
-    options+=(-m)
+    options=("-m" "-s" "${BUFFER##cd(r|) }")
 }
 
 function zaw-src-cdr-cd () {


### PR DESCRIPTION
When you use the buffer as the initial contents of a search filter,
there might be a command you typed already. However, you sometimes don't
want to start search with the command string and just copy arguments part following the
command to the search filter. For example, given `cd xyz` in your buffer and when you want to start search with zaw-cdr, you want to remove `cd ` from the search filter and just use `xyz` as the initial value. This new option `-p` enables you to define a prefix to be removed from the initial buffer contents for use cases like this.
