### PR TITLE
add draft of external source links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ Installation is easiest with a plugin manager such as
 `zgen <https://github.com/tarjoilija/zgen>`_.  Otherwise you can just source the
 .zsh file that contains the source.
 
+  - calibre source: https://github.com/junkblocker/calibre-zaw-source
   - MPD source: https://github.com/willghatch/zsh-zaw-mpd
   - todoman source: https://github.com/willghatch/zsh-zaw-todoman
 

--- a/README.rst
+++ b/README.rst
@@ -34,25 +34,25 @@ sources
 
 currently these sources are available:
 
-  - ack
-  - applications
-  - bookmark
-  - git-branches
-  - git-recent-all-branches
-  - git-recent-branches
-  - git-files
-  - git-files-legacy
-  - git-status
-  - history
-  - open-file
-  - perldoc
-  - process
-  - screens
-  - ssh-hosts
-  - tmux
-  - fasd
-  - fasd-directories
-  - fasd-files
+- ack
+- applications
+- bookmark
+- git-branches
+- git-recent-all-branches
+- git-recent-branches
+- git-files
+- git-files-legacy
+- git-status
+- history
+- open-file
+- perldoc
+- process
+- screens
+- ssh-hosts
+- tmux
+- fasd
+- fasd-directories
+- fasd-files
 
 (Note: git-files-legacy is an alternative for git-files.
 git-files classifies modified files, git-files-legacy doesn't do it for
@@ -64,9 +64,9 @@ Installation is easiest with a plugin manager such as
 `zgen <https://github.com/tarjoilija/zgen>`_.  Otherwise you can just source the
 .zsh file that contains the source.
 
-  - calibre source: https://github.com/junkblocker/calibre-zaw-source
-  - MPD source: https://github.com/willghatch/zsh-zaw-mpd
-  - todoman source: https://github.com/willghatch/zsh-zaw-todoman
+- calibre source: https://github.com/junkblocker/calibre-zaw-source
+- MPD source: https://github.com/willghatch/zsh-zaw-mpd
+- todoman source: https://github.com/willghatch/zsh-zaw-todoman
 
 shortcut widgets
 ================

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ Installation is easiest with a plugin manager such as
 
 - calibre source: https://github.com/junkblocker/calibre-zaw-source
 - MPD source: https://github.com/willghatch/zsh-zaw-mpd
+- systemd source: https://github.com/termoshtt/zaw-systemd
 - todoman source: https://github.com/willghatch/zsh-zaw-todoman
 
 shortcut widgets
@@ -173,11 +174,16 @@ ZAW_EDITOR_JUMP_PARAM   open editor command with line params.
 making sources
 ==============
 
-If you want to make another source, look in the ``sources`` directory to see
-examples.  Please put them in a git repository, and follow the
-<name>.plugin.zsh naming convention so zsh plugin managers like zgen and
-antigen can load them easily.  Let us know about your new plugins so we can add
-them to our list!
+If you want to make another source, please do!  Look at https://github.com/termoshtt/zaw-systemd
+as an example of how to make a source repo.  Note that it uses the <name>.plugin.zsh
+convention that plugin managers like zgen and antigen expect for its main file.
+The sources directory contains the files for the actual sources.  All the sources
+in this repository's ``sources`` directory are good references as well for what
+the source files should look like.  They tend to be quite simple.
+If your source requires any additional configuration or dependencies, be sure to
+list all of that in your project's README file.
+
+Let us know when you make new plugins so we can add them to our list!
 
 license
 =======

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,15 @@ currently these sources are available:
 git-files classifies modified files, git-files-legacy doesn't do it for
 performance reason.)
 
+Additional sources can be installed as third-party plugins.  Here is a list of all
+the ones we know about.  Please let us know about any more you find or make!
+Installation is easiest with a plugin manager such as 
+`zgen <https://github.com/tarjoilija/zgen>`_.  Otherwise you can just source the
+.zsh file that contains the source.
+
+  - MPD source: https://github.com/willghatch/zsh-zaw-mpd
+  - todoman source: https://github.com/willghatch/zsh-zaw-todoman
+
 shortcut widgets
 ================
 
@@ -158,6 +167,16 @@ ZAW_EDITOR_JUMP_PARAM   open editor command with line params.
                         %LINE% is replaced by line number.
                         %FILE% is replaced by file path.
                         default +%LINE% %FILE%
+
+
+making sources
+==============
+
+If you want to make another source, look in the ``sources`` directory to see
+examples.  Please put them in a git repository, and follow the
+<name>.plugin.zsh naming convention so zsh plugin managers like zgen and
+antigen can load them easily.  Let us know about your new plugins so we can add
+them to our list!
 
 license
 =======


### PR DESCRIPTION
So here's my draft of what this should look like for #68.  I think that's really all we need.  We could do with a better explanation of how to make plugins.  And we should get a bigger list of plugins to link to.

Can I just mention I really wish we were using Markdown for our readme rather than restructured text?  It took me many tries to figure out how to do inline hyperlinks right.