### PR TITLE
Require cdr

### DIFF
--- a/sources/cdr.zsh
+++ b/sources/cdr.zsh
@@ -4,7 +4,7 @@
 # zaw source for recent directories
 #
 
-(( $+functions[cdr] )) || return
+autoload -Uz cdr
 
 function zaw-src-cdr () {
     setopt local_options extended_glob


### PR DESCRIPTION
I found that cdr-source is disabled if I forget to enable cdr using `autoload` before source `zaw`.
It may be a bug, and fixed.