### PR TITLE
Reverse fasd input

### DIFF
--- a/sources/fasd.zsh
+++ b/sources/fasd.zsh
@@ -1,5 +1,5 @@
 function zaw-src-fasd () {
-    candidates=($(fasd -al))
+    candidates=($(fasd -alR))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
     options+=(-n -m)
@@ -7,7 +7,7 @@ function zaw-src-fasd () {
 
 
 function zaw-src-fasd-files () {
-    candidates=($(fasd -fl))
+    candidates=($(fasd -flR))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
     options+=(-n -m)
@@ -15,7 +15,7 @@ function zaw-src-fasd-files () {
 
 
 function zaw-src-fasd-directories () {
-    candidates=($(fasd -dl))
+    candidates=($(fasd -dlR))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
     options+=(-n -m)


### PR DESCRIPTION
`fasd` returns suggestions by ascending frecency, so the least frecent
(and therefore relevant) suggestions appear on top. By reversing the
output, the most frecent suggestion comes first in the list.

(see #75)