### PR TITLE
Pass arguments to source function

### DIFF
--- a/zaw.zsh
+++ b/zaw.zsh
@@ -66,7 +66,7 @@ function zaw-register-src() {
 
     # define shortcut function
     widget_name="zaw-${(L)name// /-}"
-    eval "function ${widget_name} { zle zaw ${func} }"
+    eval "function ${widget_name} { zle zaw ${func} \$@ }"
     eval "zle -N ${widget_name}"
 }
 


### PR DESCRIPTION
This fix passes the arguments given to `zle zaw-mysource` to the source
function, just like in the more verbose notation `zle zaw
zaw-src-mysource`.

(see #77)