### PR TITLE
history: order deduplicated history latest-first

### DIFF
--- a/sources/history.zsh
+++ b/sources/history.zsh
@@ -3,12 +3,15 @@ zmodload zsh/parameter
 function zaw-src-history() {
     if zstyle -t ':filter-select' hist-find-no-dups ; then
         candidates=(${(@vu)history})
+        options=("-m" "-s" "${BUFFER}")
     else
         cands_assoc=("${(@kv)history}")
+        # have filter-select reverse the order (back to latest command first).
+        # somehow, `cands_assoc` gets reversed while `candidates` doesn't. 
+        options=("-r" "-m" "-s" "${BUFFER}")
     fi
     actions=("zaw-callback-execute" "zaw-callback-replace-buffer" "zaw-callback-append-to-buffer")
     act_descriptions=("execute" "replace edit buffer" "append to edit buffer")
-    options=("-r" "-m" "-s" "${BUFFER}")
 
     if (( $+functions[zaw-bookmark-add] )); then
         # zaw-src-bookmark is available


### PR DESCRIPTION
Rather than earliest first. Appears to address #71 more hollistically. I don't
understand the internals of filter-select for a full root cause analysis here,
but hey, it Works On My Machine™.

`zsh 5.1.1 (x86_64-ubuntu-linux-gnu)` , in case it matters.