### PR TITLE
Improve compatibility with WARN_CREATE_GLOBAL

### DIFF
--- a/functions/filter-select
+++ b/functions/filter-select
@@ -114,6 +114,8 @@
 #
 #     If you want to search these metacharacters, please doubly escape them.
 
+typeset -ga reply_marked
+
 function filter-select() {
     emulate -L zsh
     setopt local_options extended_glob
@@ -129,6 +131,7 @@ function filter-select() {
     local key cand lines selected cand_disp buffer_pre_zle last_buffer initbuffer=''
     local opt pattern msg unused title='' exit_pattern nl=$'\n'
     local selected_index mark_idx_disp hi start end spec
+    local desc desc_num desc_disp bounds
 
     local -a displays matched_desc_keys match mbegin mend outs exit_wigdets
     local -a init_region_highlight marked_lines

--- a/sources/bookmark.zsh
+++ b/sources/bookmark.zsh
@@ -9,7 +9,7 @@
 zmodload zsh/system
 autoload -U fill-vars-or-accept
 
-BOOKMARKFILE="${BOOKMARKFILE:-"${HOME}/.zaw-bookmarks"}"
+typeset -g BOOKMARKFILE="${BOOKMARKFILE:-"${HOME}/.zaw-bookmarks"}"
 
 function zaw-src-bookmark() {
     if [[ -f "${BOOKMARKFILE}" ]]; then

--- a/sources/searcher.zsh
+++ b/sources/searcher.zsh
@@ -2,6 +2,8 @@
 
 autoload -U read-from-minibuffer
 
+typeset -g ZAW_SEARCHER_CMD
+
 if (( $+commands[ag] )); then
     ZAW_SEARCHER_CMD="ag"
 elif (( $+commands[ack-grep] )); then

--- a/zaw.zsh
+++ b/zaw.zsh
@@ -72,7 +72,7 @@ function zaw-register-src() {
 
 
 function zaw() {
-    local action ret
+    local action ret func
     local -a reply candidates actions act_descriptions options selected cand_descriptions
     local -A cands_assoc
 


### PR DESCRIPTION
In the interest of improving compatibility with the zsh option
`WARN_CREATE_GLOBAL`, include several more declarations of variables,
to explicitly declare whether they are to be local or global.

Without this change, several variables are created as global from
within functions, causing warnings with `WARN_CREATE_GLOBAL`. In some
cases, this would appear to be the intended behavior; in most cases,
it would not.

