### PR TITLE
Improve compatibility with POSIX_IDENTIFIERS

### DIFF
--- a/functions/fill-vars-or-accept
+++ b/functions/fill-vars-or-accept
@@ -27,7 +27,7 @@ function fill-vars-or-accept() {
 
     local POSTDISPLAY=$'\n''[press tab key to move cursor to next variable]'
 
-    while _buffer_has_vars && (( CURSOR < $#BUFFER )); do
+    while _buffer_has_vars && (( CURSOR < ${#BUFFER} )); do
         orig_region_highlight=("${(@)region_highlight}")
         _highlight-right-vars
         zle -Rc
@@ -52,10 +52,10 @@ function fill-vars-or-accept() {
             if [[ -n "${REPLY}" ]]; then
                 if [[ "${cmd_name}" == self-insert* ]]; then
                     # remove current var
-                    RBUFFER="${RBUFFER[$(( $#REPLY + 1)),-1]}"
+                    RBUFFER="${RBUFFER[$(( ${#REPLY} + 1)),-1]}"
                 elif [[ "${cmd_name}" == (*-delete-*|*-kill-*) ]]; then
                     # remove current var and continue
-                    RBUFFER="${RBUFFER[$(( $#REPLY + 1)),-1]}"
+                    RBUFFER="${RBUFFER[$(( ${#REPLY} + 1)),-1]}"
                     continue
                 fi
             fi
@@ -78,7 +78,7 @@ function _highlight-right-vars() {
         if [[ -n "${REPLY}" ]]; then
             region_highlight+=( "${offset} $(( offset + ${#REPLY} )) standout" )
             rbuffer="${rbuffer[$(( ${#REPLY}  )),-1]}"
-            (( offset += $#REPLY - 1 ))
+            (( offset += ${#REPLY} - 1 ))
         fi
 
         region_highlight+=( "${(f)${(S)rbuffer//*(#b)(${~FILL_VARS_PATTERN})/$(( offset + mbegin[1] - 1 )) $(( offset + mend[1] )) fg=yellow,standout${nl}}%$nl*}" )
@@ -102,7 +102,7 @@ function go-to-next-var() {
         : "${(S)rrbuffer/*(#b)(${~FILL_VARS_PATTERN})}"
         (( CURSOR += ${mbegin[1]} ))
     else
-        (( CURSOR = $#BUFFER ))
+        (( CURSOR = ${#BUFFER} ))
     fi
 }
 

--- a/functions/filter-select
+++ b/functions/filter-select
@@ -210,7 +210,7 @@ function filter-select() {
         candidates+=( $i "${cand}" )
     done
 
-    if (( $#descriptions == 0 )); then
+    if (( ${#descriptions} == 0 )); then
         # copy candidates
         descriptions=("${(@kv)candidates}")
         # add number
@@ -249,7 +249,7 @@ function filter-select() {
             init_region_highlight+="${hi}"
         else
             print -r -- "${hi}" | read start end spec
-            init_region_highlight+="P$(( start + $#orig_predisplay )) $(( end + $#orig_predisplay )) $spec"
+            init_region_highlight+="P$(( start + ${#orig_predisplay} )) $(( end + ${#orig_predisplay} )) $spec"
         fi
     done
 
@@ -268,7 +268,7 @@ function filter-select() {
             set-mark-command)
                 if (( markable )); then
                     # check if ${selected_index} is already in the marked_lines
-                    if (( ${marked_lines[(ie)${selected_index}]} <= $#marked_lines )); then
+                    if (( ${marked_lines[(ie)${selected_index}]} <= ${#marked_lines} )); then
                         # remove selected_index
                         marked_lines=("${(@)marked_lines:#${selected_index}}")
                     else
@@ -355,7 +355,7 @@ function filter-select() {
             displays=()
             offset="${#BUFFER}"
             if [[ -n "${title}" ]]; then
-                offset+=$(( 1 + $#title ))
+                offset+=$(( 1 + ${#title} ))
             fi
 
             selected=""
@@ -406,7 +406,7 @@ function filter-select() {
                     fi
 
                     mark_idx="${marked_lines[(ie)${i}]}"
-                    (( is_marked = mark_idx <= $#marked_lines ))
+                    (( is_marked = mark_idx <= ${#marked_lines} ))
 
                     if (( is_marked )); then
                         mark_idx_disp=" (${mark_idx})"
@@ -414,9 +414,9 @@ function filter-select() {
                         mark_idx_disp=""
                     fi
 
-                    if (( ${(m)#desc_disp} + $#mark_idx_disp > COLUMNS - 1 )); then
+                    if (( ${(m)#desc_disp} + ${#mark_idx_disp} > COLUMNS - 1 )); then
                         # strip long line
-                        desc_disp="${(mr:$(( COLUMNS - $#mark_idx_disp - 6 )):::::)desc_disp} ...${mark_idx_disp}"
+                        desc_disp="${(mr:$(( COLUMNS - ${#mark_idx_disp} - 6 )):::::)desc_disp} ...${mark_idx_disp}"
                     else
                         desc_disp="${desc_disp}${mark_idx_disp}"
                     fi
@@ -452,7 +452,7 @@ function filter-select() {
             POSTDISPLAY=$'\n'
             if [[ -n "${title}" ]]; then
                 POSTDISPLAY+="${title}"$'\n'
-                region_highlight+="${#BUFFER} $(( $#BUFFER + $#title + 1 )) ${hi_title}"
+                region_highlight+="${#BUFFER} $(( ${#BUFFER} + ${#title} + 1 )) ${hi_title}"
             fi
 
             if (( ${#displays} == 0 )); then
@@ -507,7 +507,7 @@ function filter-select() {
     else
         reply=("${bounds}" "${selected}")
         reply_marked=()
-        if (( $#marked_lines > 0 )); then
+        if (( ${#marked_lines} > 0 )); then
             for i in "${(@)marked_lines}"; do
                 reply_marked+="${candidates[${i}]}"
             done
@@ -632,7 +632,7 @@ function _filter-select-buffer-words() {
         : ${(A)a::=${a/#'~(#i)*\^'/'~(#i)(#s)'}}
     fi
     : ${(PA)place::=$a}
-    (( $#a > 1 )) || (( $#a == 1 )) && [[ -n "$a" ]]
+    (( ${#a} > 1 )) || (( ${#a} == 1 )) && [[ -n "$a" ]]
 }
 
 function _filter-select-init-keybind() {

--- a/sources/applications.zsh
+++ b/sources/applications.zsh
@@ -16,7 +16,7 @@ function zaw-src-applications() {
                 candidates+=(${(f)"$(mdfind -onlyin / 'kMDItemKind == "Application"' 2>/dev/null)"})
 
             # Use locate if available and no output from spotlight or if forced use by ZAW_SRC_APPLICATIONS_USE_LOCATE
-            if (( ${+commands[locate]} )) && [ -n "$ZAW_SRC_APPLICATIONS_USE_LOCATE" -o $#candidates -eq 0 ]; then
+            if (( ${+commands[locate]} )) && [ -n "$ZAW_SRC_APPLICATIONS_USE_LOCATE" -o ${#candidates} -eq 0 ]; then
                 # Apps inside apps are not normally useful
                 if [ -n "$ZAW_SRC_APPLICATIONS_INTERNAL_APPS_OK" ]; then
                     candidates+=(${(f)"$(locate -i '*.app' 2>/dev/null)"})

--- a/sources/git-files.zsh
+++ b/sources/git-files.zsh
@@ -24,7 +24,7 @@ function zaw-src-git-files-classify-aux() {
     local -a as ms ds os
     : ${(A)as::=${(0)"$(git ls-files $(git rev-parse --show-cdup) -z)"}}
     : ${(A)ms::=${(0)"$(git ls-files $(git rev-parse --show-cdup) -z -m)"}}
-    if (( $#ms == 0 )) || (( $#ms == 1 )) &&  [[ -z "$ms" ]]; then
+    if (( ${#ms} == 0 )) || (( ${#ms} == 1 )) &&  [[ -z "$ms" ]]; then
         candidates=($as)
         return 0
     fi

--- a/zaw.zsh
+++ b/zaw.zsh
@@ -100,20 +100,20 @@ function zaw() {
 
     reply=()
 
-    if (( $#cand_descriptions )); then
+    if (( ${#cand_descriptions} )); then
         options=("-d" "cand_descriptions" "${(@)options}")
     fi
     # TODO: cand_descriptions_assoc
 
     # call filter-select to allow user select item
-    if (( $#cands_assoc )); then
+    if (( ${#cands_assoc} )); then
         filter-select -e select-action -A cands_assoc "${(@)options}"
     else
         filter-select -e select-action "${(@)options}" -- "${(@)candidates}"
     fi
 
     if [[ $? == 0 ]]; then
-        if (( $#reply_marked > 0 )); then
+        if (( ${#reply_marked} > 0 )); then
             selected=("${(@)reply_marked}")
         else
             selected=("${reply[2]}")


### PR DESCRIPTION
In the interest of improving compatibility with the zsh option
`POSIX_IDENTIFIERS`, include braces (`{...}`) in parameter expansions
of the form (with braces included) `${#name}`, which expand to the
length of the parameter <name>.

While omitting the braces in such a parameter expansion expression is
permitted when `POSIX_IDENTIFIERS` is unset, it is invalid when
`POSIX_IDENTIFIERS` is set.

