### PR TITLE
Fix bad math expression error when IFS doesn't contain space

### DIFF
--- a/functions/filter-select
+++ b/functions/filter-select
@@ -251,7 +251,7 @@ function filter-select() {
         if [[ "${hi}" == P* ]]; then
             init_region_highlight+="${hi}"
         else
-            print -r -- "${hi}" | read start end spec
+            print -r -- "${hi}" | read -d ' ' start end spec
             init_region_highlight+="P$(( start + ${#orig_predisplay} )) $(( end + ${#orig_predisplay} )) $spec"
         fi
     done


### PR DESCRIPTION
When the previous prompt contains highlight and IFS doesn't contain space, calling filter-select results in the following error:

```
filter-select:136: bad math expression: operator expected at `14 fg=blue...'
```

Since the `read` command has the `-d` option to specify the delimiter, I think it's safer than relying on the user's `IFS`, which in my case was `$'\n'`.