### PR TITLE
Allow 'select-action' to confirm your choice when selecting an action

### DIFF
--- a/zaw.zsh
+++ b/zaw.zsh
@@ -128,7 +128,7 @@ function zaw() {
                 ;;
             select-action)
                 reply=()
-                filter-select -t "select action for '${(j:', ':)selected}'" -d act_descriptions -- "${(@)actions}"
+                filter-select -e select-action -t "select action for '${(j:', ':)selected}'" -d act_descriptions -- "${(@)actions}"
                 ret=$?
 
                 if [[ $ret == 0 ]]; then


### PR DESCRIPTION
This improves the ux by allowing a user to use tab to select an action.  This expands the functionality of zaw sources and makes it more intuitive to use.