### PR TITLE
Rename internal zaw source option `options` into `src_opts`

### DIFF
--- a/sources/bookmark.zsh
+++ b/sources/bookmark.zsh
@@ -17,7 +17,7 @@ function zaw-src-bookmark() {
     fi
     actions=("zaw-bookmark-execute" "zaw-callback-replace-buffer" "zaw-callback-append-to-buffer" "zaw-bookmark-remove")
     act_descriptions=("execute" "replace edit buffer" "append to edit buffer" "removed bookmark")
-    options=("-m")
+    src_opts=("-m")
 }
 
 zaw-register-src -n bookmark zaw-src-bookmark

--- a/sources/cdr.zsh
+++ b/sources/cdr.zsh
@@ -11,7 +11,7 @@ function zaw-src-cdr () {
     : ${(A)candidates::=${${(f)"$(cdr -l)"}##<-> ##}}
     actions=(zaw-src-cdr-cd zaw-src-cdr-insert zaw-src-cdr-prune)
     act_descriptions=("cd" "insert" "prune")
-    options=("-m" "-s" "${BUFFER##cd(r|) }")
+    src_opts=("-m" "-s" "${BUFFER##cd(r|) }")
 }
 
 function zaw-src-cdr-cd () {

--- a/sources/fasd.zsh
+++ b/sources/fasd.zsh
@@ -2,7 +2,7 @@ function zaw-src-fasd () {
     candidates=($(fasd -alR))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
-    options+=(-n -m)
+    src_opts+=(-n -m)
 }
 
 
@@ -10,7 +10,7 @@ function zaw-src-fasd-files () {
     candidates=($(fasd -flR))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
-    options+=(-n -m)
+    src_opts+=(-n -m)
 }
 
 
@@ -18,7 +18,7 @@ function zaw-src-fasd-directories () {
     candidates=($(fasd -dlR))
     actions=(zaw-callback-append-to-buffer)
     act_descriptions=("append to edit buffer")
-    options+=(-n -m)
+    src_opts+=(-n -m)
 }
 
 

--- a/sources/git-branches.zsh
+++ b/sources/git-branches.zsh
@@ -41,7 +41,7 @@ function zaw-src-git-branches() {
         "reset hard" \
         "delete" \
         "delete force")
-    options=()
+    src_opts=()
 }
 
 function zaw-src-git-branches-checkout () {

--- a/sources/git-files.zsh
+++ b/sources/git-files.zsh
@@ -16,7 +16,7 @@ function zaw-src-git-files-raw() {
 
     actions=(zaw-callback-edit-file zaw-src-git-status-add zaw-src-git-status-add-p zaw-src-git-status-reset zaw-src-git-status-checkout zaw-src-git-status-rm zaw-callback-append-to-buffer)
     act_descriptions=("edit file" "add" "add -p" "reset" "checkout" "rm" "append to edit buffer")
-    options=(-m -n)
+    src_opts=(-m -n)
     return 0
 }
 

--- a/sources/git-log.zsh
+++ b/sources/git-log.zsh
@@ -19,7 +19,7 @@ function zaw-src-git-log() {
                       "cherry-pick" \
                       "create new branch from this hash value" \
                       "revert")
-    options=()
+    src_opts=()
 }
 
 function _zaw-src-git-log-strip(){

--- a/sources/git-recent-branches.zsh
+++ b/sources/git-recent-branches.zsh
@@ -40,7 +40,7 @@ function zaw-src-git-recent-branches () {
         "reset hard" \
         "delete" \
         "delete force")
-    options=()
+    src_opts=()
 }
 
 function zaw-src-git-recent-all-branches () {
@@ -83,7 +83,7 @@ function zaw-src-git-recent-all-branches () {
         "reset hard" \
         "delete" \
         "delete force")
-    options=()
+    src_opts=()
 }
 
 function zaw-src-git-recent-branches-checkout () {

--- a/sources/git-reflog.zsh
+++ b/sources/git-reflog.zsh
@@ -9,7 +9,7 @@ function zaw-src-git-reflog () {
     fi
     actions=(zaw-callback-append-to-buffer zaw-src-git-commit-checkout zaw-src-git-commit-reset zaw-src-git-commit-rebase zaw-src-git-commit-rebase-interactive zaw-src-git-commit-reset-hard)
     act_descriptions=("append to edit buffer" "checkout" "reset" "rebase" "rebase interactive from..." "reset hard")
-    options=()
+    src_opts=()
 }
 
 function zaw-src-git-commit-checkout () {

--- a/sources/git-status.zsh
+++ b/sources/git-status.zsh
@@ -30,7 +30,7 @@ function zaw-src-git-status() {
       "checkout" \
       "edit" \
       "rm")
-    options=()
+    src_opts=()
 }
 
 function zaw-src-git-status-add() {

--- a/sources/history.zsh
+++ b/sources/history.zsh
@@ -3,12 +3,12 @@ zmodload zsh/parameter
 function zaw-src-history() {
     if zstyle -t ':filter-select' hist-find-no-dups ; then
         candidates=(${(@vu)history})
-        options=("-m" "-s" "${BUFFER}")
+        src_opts=("-m" "-s" "${BUFFER}")
     else
         cands_assoc=("${(@kv)history}")
         # have filter-select reverse the order (back to latest command first).
         # somehow, `cands_assoc` gets reversed while `candidates` doesn't. 
-        options=("-r" "-m" "-s" "${BUFFER}")
+        src_opts=("-r" "-m" "-s" "${BUFFER}")
     fi
     actions=("zaw-callback-execute" "zaw-callback-replace-buffer" "zaw-callback-append-to-buffer")
     act_descriptions=("execute" "replace edit buffer" "append to edit buffer")

--- a/sources/open-file.zsh
+++ b/sources/open-file.zsh
@@ -35,8 +35,8 @@ function zaw-src-open-file() {
     actions=( "zaw-callback-open-file" "zaw-callback-append-to-buffer" )
     act_descriptions=( "open file or directory" "append to edit buffer" )
     # TODO: open multiple files
-    #options=( "-m" )
-    options=( "-t" "${root}" )
+    #src_opts=( "-m" )
+    src_opts=( "-t" "${root}" )
 }
 
 zaw-register-src -n open-file zaw-src-open-file

--- a/sources/process.zsh
+++ b/sources/process.zsh
@@ -14,7 +14,7 @@ function zaw-src-process () {
     : ${(A)cand_descriptions::=${(f)ps}}
     actions=(zaw-callback-append-to-buffer zaw-src-process-kill)
     act_descriptions=("insert" "kill")
-    options=(-t "$title")
+    src_opts=(-t "$title")
 }
 
 function zaw-src-process-kill () {

--- a/zaw-launcher.zsh
+++ b/zaw-launcher.zsh
@@ -21,7 +21,7 @@ while getopts 'eh' opt; do
 
         h)
             print \
-"Usage: $0 [options] [source name]
+"Usage: $0 [src_opts] [source name]
 
 Options:
   -h     show this help

--- a/zaw.zsh
+++ b/zaw.zsh
@@ -43,7 +43,7 @@ function zaw-register-src() {
     # $cand_descriptions_assoc -> (optional) assoc array of candidates descriptions
     # $actions           -> list of callback function names that receive selected item
     # $act_descriptions  -> (optional) list of callback function descriptions
-    # $options           -> (optional) array of options passed to filter-select
+    # $src_opts           -> (optional) array of src_opts passed to filter-select
     #
     # whether one of candidates or cands-assoc is required
     local name func widget_name opts OPTARG OPTIND
@@ -73,7 +73,7 @@ function zaw-register-src() {
 
 function zaw() {
     local action ret func
-    local -a reply candidates actions act_descriptions options selected cand_descriptions
+    local -a reply candidates actions act_descriptions src_opts selected cand_descriptions
     local -A cands_assoc
 
     if [[ $# == 0 ]]; then
@@ -101,15 +101,15 @@ function zaw() {
     reply=()
 
     if (( ${#cand_descriptions} )); then
-        options=("-d" "cand_descriptions" "${(@)options}")
+        src_opts=("-d" "cand_descriptions" "${(@)src_opts}")
     fi
     # TODO: cand_descriptions_assoc
 
     # call filter-select to allow user select item
     if (( ${#cands_assoc} )); then
-        filter-select -e select-action -A cands_assoc "${(@)options}"
+        filter-select -e select-action -A cands_assoc "${(@)src_opts}"
     else
-        filter-select -e select-action "${(@)options}" -- "${(@)candidates}"
+        filter-select -e select-action "${(@)src_opts}" -- "${(@)candidates}"
     fi
 
     if [[ $? == 0 ]]; then


### PR DESCRIPTION
Resolve #93, and related to https://github.com/zsh-users/zsh-syntax-highlighting/issues/500

This will be a large breaking change since this PR changes how to define sources.