### PR TITLE
Allow for custom actions on enter/meta-enter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,8 @@ and these zstyles to customize styles::
   ':filter-select' extended-search
   ':filter-select' hist-find-no-dups
   ':filter-select' escape-descriptions
+  ':zaw:<source-name>' default <func_name|action description>
+  ':zaw:<source-name>' alt <func_name|action description>
 
   example:
     zstyle ':filter-select:highlight' matched fg=yellow,standout
@@ -164,6 +166,10 @@ and these zstyles to customize styles::
     zstyle ':filter-select' extended-search yes # see below
     zstyle ':filter-select' hist-find-no-dups yes # ignore duplicates in history source
     zstyle ':filter-select' escape-descriptions no # display literal newlines, not \n, etc
+    zstyle ':zaw:git-files' default zaw-callback-append-to-buffer # set default action for git-files
+    zstyle ':zaw:git-files' default "append to edit buffer" # same as the example above, but using description
+    zstyle ':zaw:git-files' alt zaw-callback-edit-file # set the alt action for git-files
+    zstyle ':zaw:git-files' alt "edit file" # same as the example above, but using description
 
   extended-search:
       If this style set to be true value, the searching bahavior will be

--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,8 @@ and these zstyles to customize styles::
   ':filter-select' extended-search
   ':filter-select' hist-find-no-dups
   ':filter-select' escape-descriptions
-  ':zaw:<source-name>' default <func_name|action description>
-  ':zaw:<source-name>' alt <func_name|action description>
+  ':zaw:<source-name>' default <func_name>
+  ':zaw:<source-name>' alt <func_name>
 
   example:
     zstyle ':filter-select:highlight' matched fg=yellow,standout
@@ -167,9 +167,7 @@ and these zstyles to customize styles::
     zstyle ':filter-select' hist-find-no-dups yes # ignore duplicates in history source
     zstyle ':filter-select' escape-descriptions no # display literal newlines, not \n, etc
     zstyle ':zaw:git-files' default zaw-callback-append-to-buffer # set default action for git-files
-    zstyle ':zaw:git-files' default "append to edit buffer" # same as the example above, but using description
     zstyle ':zaw:git-files' alt zaw-callback-edit-file # set the alt action for git-files
-    zstyle ':zaw:git-files' alt "edit file" # same as the example above, but using description
 
   extended-search:
       If this style set to be true value, the searching bahavior will be

--- a/zaw.zsh
+++ b/zaw.zsh
@@ -154,8 +154,8 @@ function zaw() {
                 if [[ ${#actions} -eq 1 ]]; then
                     action="$(zaw-action "${name}" 1)"
                 else
-                    act_descriptions[${actions[(ie)$(zaw-action "${name}" 1)]}]+=" (Enter)"
-                    act_descriptions[${actions[(ie)$(zaw-action "${name}" 2)]}]+=" (Meta-enter)"
+                    act_descriptions[${actions[(ie)$(zaw-action "${name}" 1)]}]+=" (Default)"
+                    act_descriptions[${actions[(ie)$(zaw-action "${name}" 2)]}]+=" (Alternative)"
                     reply=()
                     filter-select -e select-action -t "select action for '${(j:', ':)selected}'" -d act_descriptions -- "${(@)actions}"
                     ret=$?

--- a/zaw.zsh
+++ b/zaw.zsh
@@ -70,32 +70,31 @@ function zaw-register-src() {
     eval "zle -N ${widget_name}"
 }
 
-function zaw-replace-descriptions-with-action-names() {
-    local desc_index="${act_descriptions[(ie)$action_default]}"
-    [[ $desc_index -le ${#act_descriptions} ]] && action_default="${actions[$desc_index]}"
-    desc_index="${act_descriptions[(ie)$action_alt]}"
-    [[ $desc_index -le ${#act_descriptions} ]] && action_alt="${actions[$desc_index]}"
-}
-
-function zaw-get-action-defaults() {
+function zaw-name-from-func() {
     local name func
     func="$1"
-    for k in "${(@k)zaw_sources}"; do
-        if [[ "${zaw_sources[$k]}" == "$func" ]]; then
-            name="$k"
-            break
+    for name in "${(@k)zaw_sources}"; do
+        if [[ "${zaw_sources[$name]}" == "$func" ]]; then
+            echo "$name"
+            return
         fi
     done
-    zstyle_name="${(L)name// /-}"
-    zstyle -s ":zaw:${zstyle_name}" default action_default
-    zstyle -s ":zaw:${zstyle_name}" alt action_alt
-    zaw-replace-descriptions-with-action-names
-    [[ ${actions[(ie)$action_default]} -le ${#actions} ]] || action_default="${actions[1]}"
-    [[ ${actions[(ie)$action_alt]} -le ${#actions} ]] || action_alt="${actions[2]}"
+}
+
+function zaw-action() {
+    local idx name value
+    local -a styles=(default alt)
+    name="$1"
+    idx="$2"
+    if zstyle -s ":zaw:${name}" "${styles[$idx]}" value && [[ ${actions[(ie)$value]} -le ${#actions} ]]; then
+        echo "${value}"
+    else
+        echo "${actions[$idx]}"
+    fi
 }
 
 function zaw() {
-    local action ret func
+    local action ret func name
     local -a reply candidates actions act_descriptions src_opts selected cand_descriptions
     local -A cands_assoc
 
@@ -142,21 +141,21 @@ function zaw() {
             selected=("${reply[2]}")
         fi
 
-        zaw-get-action-defaults "${func}"
+        name=$(zaw-name-from-func "${func}")
 
         case "${reply[1]}" in
             accept-line)
-                action="${action_default}"
+                action="$(zaw-action "${name}" 1)"
                 ;;
             accept-search)
-                action="${action_alt}"
+                action="$(zaw-action "${name}" 2)"
                 ;;
             select-action)
                 if [[ ${#actions} -eq 1 ]]; then
-                    action="${actions[1]}"
+                    action="$(zaw-action "${name}" 1)"
                 else
-                    act_descriptions[${actions[(ie)$action_default]}]+=" (Enter)"
-                    act_descriptions[${actions[(ie)$action_alt]}]+=" (Meta-enter)"
+                    act_descriptions[${actions[(ie)$(zaw-action "${name}" 1)]}]+=" (Enter)"
+                    act_descriptions[${actions[(ie)$(zaw-action "${name}" 2)]}]+=" (Meta-enter)"
                     reply=()
                     filter-select -e select-action -t "select action for '${(j:', ':)selected}'" -d act_descriptions -- "${(@)actions}"
                     ret=$?


### PR DESCRIPTION
The custom actions may be set using zstyle configuration. Configuration
is set in the following way:

    zstyle ':zaw:<source-name>' default "<func-name|action description>"
    zstyle ':zaw:<source-name>' alt "<func-name|action description>"

Also add "(Enter)" or "(Meta-enter)" to the description of actions when
selecting an action.

An example:

```
# Set default action for git-files using the description
zstyle ':zaw:git-files' default 'append to edit buffer'
# Set alternate action for git-files using the name of function
zstyle ':zaw:git-files' alt zaw-callback-edit-file
```

Now using Enter/Meta-enter will use the actions mentioned above. When tab is hit and an action is being selected, the following will be displayed, highlighting the default/alt actions for future use:

```
filter:
select action for 'zaw.zsh'
edit file (Meta-enter)
add
add -p
reset
checkout
rm
append to edit buffer (Enter)
[1/7]
```
